### PR TITLE
Refactor types and functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,12 +42,6 @@
       {
         "custom": "ignore"
       }
-    ],
-    "no-plusplus": [
-      "error",
-      {
-        "allowForLoopAfterthoughts": true
-      }
     ]
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="theme-color" content="#000000">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="theme-color" content="#000000" />
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
     <!-- <link rel="manifest" href="%PUBLIC_URL%/manifest.json"> -->
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -19,7 +19,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <link href="https://fonts.googleapis.com/css?family=Quicksand:400,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Quicksand:400,700" rel="stylesheet" />
     <title>React App</title>
   </head>
   <body>
@@ -27,7 +27,7 @@
       You need to enable JavaScript to run this app.
     </noscript>
     <div id="root"></div>
-    <a href="https://github.com/manorossa/seven-star-sums">Link to GitHub</a>
+    <a href="https://github.com/ManoMylv-Inviqa/seven-star-sums">Link to GitHub</a>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/HOCs/withAnimation/withAnimation.tsx
+++ b/src/HOCs/withAnimation/withAnimation.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import CSSTransition from 'react-transition-group/CSSTransition';
-import { AppState } from '../../types/types';
+import { StatusState } from '../../types/types';
 import { useStatus } from '../../context/StatusContext';
 
 const withAnimation = <P extends object>(
   WrappedComponent: React.ComponentType<P>,
-  showStatus: AppState['gameStatus']
+  showStatus: StatusState['gameStatus']
 ) => (props: P): JSX.Element => {
   const { gameStatus } = useStatus();
   const show = gameStatus === showStatus;

--- a/src/components/GameSheet/Score/Score.tsx
+++ b/src/components/GameSheet/Score/Score.tsx
@@ -3,22 +3,18 @@ import Star from '../../../UI/atoms/Icons/Star';
 import Heart from '../../../UI/atoms/Icons/Heart';
 import './Score.css';
 import { useScore } from '../../../context/ScoreContext';
+import { getNumberRange } from '../../../helpers/helpers';
 
 const Score: React.FC = () => {
   const { totalLives, livesLeft, score } = useScore();
-  const stars = [];
-  if (score !== undefined) {
-    for (let i = 1; i <= 7; i++) {
-      stars.push(
-        <Star key={`star-${i}`} fill={i <= score ? '#fff100' : '#ccc'} stroke={i <= score ? '#ff9b00' : '#888'} />
-      );
-    }
-  }
 
-  const hearts = [];
-  for (let j = 1; j <= totalLives; j++) {
-    hearts.push(<Heart key={`heart-${j}`} fill={j <= livesLeft ? '#e74c3c' : '#220277'} />);
-  }
+  const stars = Array.from(getNumberRange(7), (i) => {
+    return <Star key={`star-${i}`} fill={i <= score ? '#fff100' : '#ccc'} stroke={i <= score ? '#ff9b00' : '#888'} />;
+  });
+
+  const hearts = Array.from(getNumberRange(totalLives), (j) => {
+    return <Heart key={`heart-${j}`} fill={j <= livesLeft ? '#e74c3c' : '#220277'} />;
+  });
 
   return (
     <div className="score-strip">

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -16,17 +16,17 @@ const SettingsSheet: React.FC = () => {
   const [difficulty, setDifficulty] = useState(7);
 
   // PANEL HANDLERS START
-  const panel1Handler = (chosenOperator: SumState['op1']): void => {
+  const panel1Handler: GenericFunc<SumState['op1']> = (chosenOperator) => {
     setSettingStatus(2);
-    setOperator(chosenOperator);
+    setOperator(chosenOperator as SumState['op1']);
   };
 
-  const panel2Handler = (chosenBaseNum: number): void => {
+  const panel2Handler: GenericFunc<number> = (chosenBaseNum) => {
     setSettingStatus(3);
     setPanelBaseNum(chosenBaseNum);
   };
 
-  const panel3Handler = (lives: number): void => {
+  const panel3Handler: GenericFunc<number> = (lives) => {
     setSettingStatus(4);
     setDifficulty(lives);
   };
@@ -62,15 +62,15 @@ const SettingsSheet: React.FC = () => {
 
   // CREATE BUTTON MAPS
   const buttonMap = (
-    options: OptionsMap<string | number>,
+    options: OptionsMap<string | number | SumState['op1']>,
     stateCheck: string | number,
     panelNum: number,
-    clickHandler: GenericFunc,
+    clickHandler: GenericFunc<SumState['op1'] & number>,
     buttonStyle: string[][],
     buttonText: number[] | string[]
   ): JSX.Element[] =>
     options.map(
-      (option: string | number, index: number): JSX.Element => {
+      (option: string | number | SumState['op1'], index: number): JSX.Element => {
         const [butMod, butModAct, butModInact] = buttonStyle;
         let buttonModifiers = butMod;
         if (settingStatus > panelNum) {
@@ -80,7 +80,7 @@ const SettingsSheet: React.FC = () => {
           <Button
             key={`panel-${panelNum}-${option}`}
             type="button"
-            handler={(): void => clickHandler(option)}
+            handler={(): void => clickHandler(option as SumState['op1'] & number)}
             modifiers={buttonModifiers}
           >
             {buttonText[index]}

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Button from '../../UI/atoms/Button/Button';
 import './SettingsSheet.css';
-import { GenericFunc, SumState } from '../../types/types';
+import { GenericFunc, OptionsMap, SumState } from '../../types/types';
 import { useStatus } from '../../context/StatusContext';
 import { useSum } from '../../context/SumContext';
 import { useScore } from '../../context/ScoreContext';
@@ -62,9 +62,7 @@ const SettingsSheet: React.FC = () => {
 
   // CREATE BUTTON MAPS
   const buttonMap = (
-    // @to-do: look into generics to get round use of any here
-    /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
-    options: any,
+    options: OptionsMap<string | number>,
     stateCheck: string | number,
     panelNum: number,
     clickHandler: GenericFunc,

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Button from '../../UI/atoms/Button/Button';
 import './SettingsSheet.css';
-import { SettingsPayload, GenericFunc } from '../../types/types';
+import { GenericFunc, SumState } from '../../types/types';
 import { useStatus } from '../../context/StatusContext';
 import { useSum } from '../../context/SumContext';
 import { useScore } from '../../context/ScoreContext';
@@ -11,12 +11,12 @@ const SettingsSheet: React.FC = () => {
   const { setBaseNum, setOp1 } = useSum();
   const { setTotalLives } = useScore();
   const [settingStatus, setSettingStatus] = useState(1);
-  const [operator, setOperator] = useState('+' as SettingsPayload['finalOperator']);
+  const [operator, setOperator] = useState('+' as SumState['op1']);
   const [panelBaseNum, setPanelBaseNum] = useState(2);
   const [difficulty, setDifficulty] = useState(7);
 
   // PANEL HANDLERS START
-  const panel1Handler = (chosenOperator: SettingsPayload['finalOperator']): void => {
+  const panel1Handler = (chosenOperator: SumState['op1']): void => {
     setSettingStatus(2);
     setOperator(chosenOperator);
   };
@@ -124,11 +124,7 @@ const SettingsSheet: React.FC = () => {
     difficultyText
   );
 
-  const finalSettings = (
-    finalBaseNum: number,
-    finalOperator: SettingsPayload['finalOperator'],
-    finalDifficulty: number
-  ): void => {
+  const finalSettings = (finalBaseNum: number, finalOperator: SumState['op1'], finalDifficulty: number): void => {
     setBaseNum(finalBaseNum);
     setOp1(finalOperator);
     setTotalLives(finalDifficulty);

--- a/src/context/AnswerContext.tsx
+++ b/src/context/AnswerContext.tsx
@@ -1,21 +1,21 @@
 import React, { useState, useMemo, useContext } from 'react';
-import { AppState, AnswerContextValues, Props } from '../types/types';
+import { AppState, AnswerState, Props } from '../types/types';
 
-const AnswerContext = React.createContext<Partial<AnswerContextValues>>({});
+const AnswerContext = React.createContext<Partial<AnswerState>>({});
 const { Provider } = AnswerContext;
 
 const AnswerProvider = ({ children }: Props): JSX.Element => {
   const [possibleAns, setPossibleAns] = useState([] as number[]);
   const [correctAns, setCorrectAns] = useState(null as AppState['correctAns']);
 
-  const answerContextValues = useMemo(() => ({ possibleAns, correctAns, setPossibleAns, setCorrectAns }), [
+  const answerState = useMemo(() => ({ possibleAns, correctAns, setPossibleAns, setCorrectAns }), [
     possibleAns,
     correctAns
   ]);
-  return <Provider value={answerContextValues}>{children}</Provider>;
+  return <Provider value={answerState}>{children}</Provider>;
 };
 
-const useAnswer = (): AnswerContextValues => {
+const useAnswer = (): AnswerState => {
   const { possibleAns, correctAns, setPossibleAns, setCorrectAns } = useContext(AnswerContext);
 
   if (

--- a/src/context/AnswerContext.tsx
+++ b/src/context/AnswerContext.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useMemo, useContext } from 'react';
-import { AppState, AnswerState, Props } from '../types/types';
+import { AnswerState, Props } from '../types/types';
 
 const AnswerContext = React.createContext<Partial<AnswerState>>({});
 const { Provider } = AnswerContext;
 
 const AnswerProvider = ({ children }: Props): JSX.Element => {
   const [possibleAns, setPossibleAns] = useState([] as number[]);
-  const [correctAns, setCorrectAns] = useState(null as AppState['correctAns']);
+  const [correctAns, setCorrectAns] = useState(null as AnswerState['correctAns']);
 
   const answerState = useMemo(() => ({ possibleAns, correctAns, setPossibleAns, setCorrectAns }), [
     possibleAns,

--- a/src/context/ScoreContext.tsx
+++ b/src/context/ScoreContext.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext, useMemo } from 'react';
-import { ScoreContextValues, Props } from '../types/types';
+import { ScoreState, Props } from '../types/types';
 
-const ScoreContext = React.createContext<Partial<ScoreContextValues>>({});
+const ScoreContext = React.createContext<Partial<ScoreState>>({});
 const { Provider } = ScoreContext;
 
 const ScoreProvider = ({ children }: Props): JSX.Element => {
@@ -9,7 +9,7 @@ const ScoreProvider = ({ children }: Props): JSX.Element => {
   const [livesLeft, setLivesLeft] = useState(7);
   const [score, setScore] = useState(0);
 
-  const scoreContextValues = useMemo(
+  const scoreState = useMemo(
     () => ({
       totalLives,
       livesLeft,
@@ -20,10 +20,10 @@ const ScoreProvider = ({ children }: Props): JSX.Element => {
     }),
     [totalLives, livesLeft, score]
   );
-  return <Provider value={scoreContextValues}>{children}</Provider>;
+  return <Provider value={scoreState}>{children}</Provider>;
 };
 
-const useScore = (): ScoreContextValues => {
+const useScore = (): ScoreState => {
   const { totalLives, livesLeft, score, setTotalLives, setLivesLeft, setScore } = useContext(ScoreContext);
 
   if (

--- a/src/context/StatusContext.tsx
+++ b/src/context/StatusContext.tsx
@@ -1,22 +1,22 @@
 import React, { useState, useMemo, useContext } from 'react';
-import { GameStates, Props, StatusContextValues } from '../types/types';
+import { GameStates, Props, StatusState } from '../types/types';
 
-const StatusContext = React.createContext<Partial<StatusContextValues>>({ gameStatus: 'showSettings' });
+const StatusContext = React.createContext<Partial<StatusState>>({ gameStatus: 'showSettings' });
 const { Provider } = StatusContext;
 
 const StatusProvider = ({ children }: Props): JSX.Element => {
   const [gameStatus, setGameStatus] = useState('showSettings' as GameStates);
   const [showSplash, setShowSplash] = useState(false);
 
-  const statusContextValues = useMemo(() => ({ gameStatus, showSplash, setGameStatus, setShowSplash }), [
+  const statusState = useMemo(() => ({ gameStatus, showSplash, setGameStatus, setShowSplash }), [
     gameStatus,
     showSplash
   ]);
 
-  return <Provider value={statusContextValues}>{children}</Provider>;
+  return <Provider value={statusState}>{children}</Provider>;
 };
 
-const useStatus = (): StatusContextValues => {
+const useStatus = (): StatusState => {
   const { gameStatus, showSplash, setGameStatus, setShowSplash } = useContext(StatusContext);
 
   if (

--- a/src/context/SumContext.tsx
+++ b/src/context/SumContext.tsx
@@ -1,17 +1,17 @@
 import React, { useState, useMemo, useContext } from 'react';
-import { AppState, SumState, Props } from '../types/types';
+import { SumState, Props } from '../types/types';
 
 const SumContext = React.createContext<Partial<SumState>>({});
 const { Provider } = SumContext;
 
 const SumProvider = ({ children }: Props): JSX.Element => {
-  const [possibleNums, setPossibleNums] = useState([] as AppState['possibleNums']);
-  const [num1, setNum1] = useState(null as AppState['num1']);
-  const [num2, setNum2] = useState('?' as AppState['num2']);
+  const [possibleNums, setPossibleNums] = useState([] as SumState['possibleNums']);
+  const [num1, setNum1] = useState(null as SumState['num1']);
+  const [num2, setNum2] = useState('?' as SumState['num2']);
   const [baseNum, setBaseNum] = useState(20);
-  const [op1, setOp1] = useState('+' as AppState['op1']);
+  const [op1, setOp1] = useState('+' as SumState['op1']);
   const [op2, setOp2] = useState('=');
-  const [rightWrong, setRightWrong] = useState(null as AppState['rightWrong']);
+  const [rightWrong, setRightWrong] = useState(null as SumState['rightWrong']);
 
   const sumState = useMemo(
     () => ({

--- a/src/context/SumContext.tsx
+++ b/src/context/SumContext.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useContext } from 'react';
-import { AppState, SumContextValues, Props } from '../types/types';
+import { AppState, SumState, Props } from '../types/types';
 
-const SumContext = React.createContext<Partial<SumContextValues>>({});
+const SumContext = React.createContext<Partial<SumState>>({});
 const { Provider } = SumContext;
 
 const SumProvider = ({ children }: Props): JSX.Element => {
@@ -13,7 +13,7 @@ const SumProvider = ({ children }: Props): JSX.Element => {
   const [op2, setOp2] = useState('=');
   const [rightWrong, setRightWrong] = useState(null as AppState['rightWrong']);
 
-  const sumContextValues = useMemo(
+  const sumState = useMemo(
     () => ({
       possibleNums,
       num1,
@@ -33,10 +33,10 @@ const SumProvider = ({ children }: Props): JSX.Element => {
     [possibleNums, num1, num2, baseNum, op1, op2, rightWrong]
   );
 
-  return <Provider value={sumContextValues}>{children}</Provider>;
+  return <Provider value={sumState}>{children}</Provider>;
 };
 
-const useSum = (): SumContextValues => {
+const useSum = (): SumState => {
   const {
     possibleNums,
     num1,

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -5,12 +5,8 @@ export const getRandomNumber = (base: number): number => {
 };
 
 export const definePossibleNums = (baseNum: SumState['baseNum'], op1: SumState['op1']): number[] => {
-  const newNums = [];
-  const numLimit = op1 === '+' ? baseNum : 13;
-  for (let i = 1; i < numLimit; i++) {
-    newNums.push(i);
-  }
-  return newNums;
+  const numLimit = op1 === '+' ? baseNum : 12;
+  return Array.from(new Array(numLimit), (_, index) => index + 1);
 };
 
 export const defineSum = (

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -4,9 +4,13 @@ export const getRandomNumber = (base: number): number => {
   return Math.floor(Math.random() * Math.floor(base));
 };
 
+export const getNumberRange = (endNum: number): number[] => {
+  return Array.from(new Array(endNum), (_, index) => index + 1);
+};
+
 export const definePossibleNums = (baseNum: SumState['baseNum'], op1: SumState['op1']): number[] => {
   const numLimit = op1 === '+' ? baseNum : 12;
-  return Array.from(new Array(numLimit), (_, index) => index + 1);
+  return getNumberRange(numLimit);
 };
 
 export const defineSum = (

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -8,6 +8,18 @@ export const getNumberRange = (endNum: number): number[] => {
   return Array.from(new Array(endNum), (_, index) => index + 1);
 };
 
+const getRandomIndexSet = (setSize: number): Set<number> => {
+  const randomSet = new Set<number>();
+  let i = 0;
+  let a;
+  while (i < 3) {
+    a = getRandomNumber(setSize);
+    randomSet.add(a);
+    i = randomSet.size;
+  }
+  return randomSet;
+};
+
 export const definePossibleNums = (baseNum: SumState['baseNum'], op1: SumState['op1']): number[] => {
   const numLimit = op1 === '+' ? baseNum : 12;
   return getNumberRange(numLimit);
@@ -38,14 +50,8 @@ export const defineSum = (
   // Put the possible answers into an array, ready to be shuffled
   const answerArray = [answer1, answer2, answer3];
   // Create a random order of indices of 0, 1 and 2
-  const answerSet: Set<number> = new Set();
-  let i = 0;
-  let a;
-  while (i < 3) {
-    a = getRandomNumber(3);
-    answerSet.add(a);
-    i = answerSet.size;
-  }
+  const answerSet: Set<number> = getRandomIndexSet(3);
+
   // shuffle the possible answer array according to the random order of indices
   const possibleAns = [...answerSet].map((x) => answerArray[x]);
 

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,10 +1,10 @@
-import { AppState, AnswerMethodsObj, DefineSumResult } from '../types/types';
+import { SumState, AnswerMethodsObj, DefineSumResult } from '../types/types';
 
 export const getRandomNumber = (base: number): number => {
   return Math.floor(Math.random() * Math.floor(base));
 };
 
-export const definePossibleNums = (baseNum: AppState['baseNum'], op1: AppState['op1']): number[] => {
+export const definePossibleNums = (baseNum: SumState['baseNum'], op1: SumState['op1']): number[] => {
   const newNums = [];
   const numLimit = op1 === '+' ? baseNum : 13;
   for (let i = 1; i < numLimit; i++) {
@@ -14,9 +14,9 @@ export const definePossibleNums = (baseNum: AppState['baseNum'], op1: AppState['
 };
 
 export const defineSum = (
-  possibleNums: AppState['possibleNums'],
-  baseNum: AppState['baseNum'],
-  op1: AppState['op2']
+  possibleNums: SumState['possibleNums'],
+  baseNum: SumState['baseNum'],
+  op1: SumState['op2']
 ): DefineSumResult => {
   // Choose a random number from the possible numbers array,
   // based on the length of the possible numbers array

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,13 +1,16 @@
 import { SumState, AnswerMethodsObj, DefineSumResult } from '../types/types';
 
+// fn retuns a random integer with a ceiling based on the number given
 export const getRandomNumber = (base: number): number => {
   return Math.floor(Math.random() * Math.floor(base));
 };
 
+// fn returns an array of numbers in order from 1 to endNum
 export const getNumberRange = (endNum: number): number[] => {
   return Array.from(new Array(endNum), (_, index) => index + 1);
 };
 
+// fn returns a set of numbers in random order from 0 to setSize
 const getRandomIndexSet = (setSize: number): Set<number> => {
   const randomSet = new Set<number>();
   let i = 0;
@@ -20,11 +23,14 @@ const getRandomIndexSet = (setSize: number): Set<number> => {
   return randomSet;
 };
 
+// fn returns an array of numbers in order based on the type of sum chosen in settings
 export const definePossibleNums = (baseNum: SumState['baseNum'], op1: SumState['op1']): number[] => {
   const numLimit = op1 === '+' ? baseNum : 12;
   return getNumberRange(numLimit);
 };
 
+// fn pulls out a random number from possible number, returns an array of randomised possible
+// answers of the correct one, and two others, also returns the correct answer by itself
 export const defineSum = (
   possibleNums: SumState['possibleNums'],
   baseNum: SumState['baseNum'],

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -19,30 +19,30 @@ type Operator1 = '+' | 'x';
 export type Props = { children: ReactNode };
 type StateSetter<T> = React.Dispatch<React.SetStateAction<T>>;
 
-export type AnswerContextValues = {
+export type AnswerState = {
   possibleAns: number[];
   correctAns: number | null;
-  setPossibleAns: StateSetter<AnswerContextValues['possibleAns']>;
-  setCorrectAns: StateSetter<AnswerContextValues['correctAns']>;
+  setPossibleAns: StateSetter<AnswerState['possibleAns']>;
+  setCorrectAns: StateSetter<AnswerState['correctAns']>;
 };
 
-export type ScoreContextValues = {
+export type ScoreState = {
   totalLives: number;
   livesLeft: number;
   score: number;
-  setTotalLives: StateSetter<ScoreContextValues['totalLives']>;
-  setLivesLeft: StateSetter<ScoreContextValues['livesLeft']>;
-  setScore: StateSetter<ScoreContextValues['score']>;
+  setTotalLives: StateSetter<ScoreState['totalLives']>;
+  setLivesLeft: StateSetter<ScoreState['livesLeft']>;
+  setScore: StateSetter<ScoreState['score']>;
 };
 
-export type StatusContextValues = {
+export type StatusState = {
   gameStatus: GameStates;
   showSplash: boolean;
-  setGameStatus: StateSetter<StatusContextValues['gameStatus']>;
-  setShowSplash: StateSetter<StatusContextValues['showSplash']>;
+  setGameStatus: StateSetter<StatusState['gameStatus']>;
+  setShowSplash: StateSetter<StatusState['showSplash']>;
 };
 
-export type SumContextValues = {
+export type SumState = {
   possibleNums: number[];
   num1: number | null;
   num2: AnswerButton;
@@ -50,13 +50,13 @@ export type SumContextValues = {
   op1: Operator1;
   op2: string;
   rightWrong: boolean | null;
-  setPossibleNums: StateSetter<SumContextValues['possibleNums']>;
-  setNum1: StateSetter<SumContextValues['num1']>;
-  setNum2: StateSetter<SumContextValues['num2']>;
-  setBaseNum: StateSetter<SumContextValues['baseNum']>;
-  setOp1: StateSetter<SumContextValues['op1']>;
-  setOp2: StateSetter<SumContextValues['op2']>;
-  setRightWrong: StateSetter<SumContextValues['rightWrong']>;
+  setPossibleNums: StateSetter<SumState['possibleNums']>;
+  setNum1: StateSetter<SumState['num1']>;
+  setNum2: StateSetter<SumState['num2']>;
+  setBaseNum: StateSetter<SumState['baseNum']>;
+  setOp1: StateSetter<SumState['op1']>;
+  setOp2: StateSetter<SumState['op2']>;
+  setRightWrong: StateSetter<SumState['rightWrong']>;
 };
 
 export interface AppState {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -59,17 +59,14 @@ export type SumState = {
   setRightWrong: StateSetter<SumState['rightWrong']>;
 };
 
+// METHOD AND FUNCTION TYPES
+
 interface AnswerMethod {
   (a: number, b: number): number;
 }
 
 export interface AnswerMethodsObj {
   [key: string]: AnswerMethod;
-}
-
-export interface SettingsPayload {
-  finalBaseNum: number;
-  finalOperator: Operator1;
 }
 
 // @to-do: look into generics to get round use of any here

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react';
 
+// CONTEXT AND STATE TYPES
+
 export type GameStates =
   | 'startGame'
   | 'showSettings'
@@ -13,6 +15,49 @@ export type GameStates =
 
 type AnswerButton = number | '?';
 type Operator1 = '+' | 'x';
+
+export type Props = { children: ReactNode };
+type StateSetter<T> = React.Dispatch<React.SetStateAction<T>>;
+
+export type AnswerContextValues = {
+  possibleAns: number[];
+  correctAns: number | null;
+  setPossibleAns: StateSetter<AnswerContextValues['possibleAns']>;
+  setCorrectAns: StateSetter<AnswerContextValues['correctAns']>;
+};
+
+export type ScoreContextValues = {
+  totalLives: number;
+  livesLeft: number;
+  score: number;
+  setTotalLives: StateSetter<ScoreContextValues['totalLives']>;
+  setLivesLeft: StateSetter<ScoreContextValues['livesLeft']>;
+  setScore: StateSetter<ScoreContextValues['score']>;
+};
+
+export type StatusContextValues = {
+  gameStatus: GameStates;
+  showSplash: boolean;
+  setGameStatus: StateSetter<StatusContextValues['gameStatus']>;
+  setShowSplash: StateSetter<StatusContextValues['showSplash']>;
+};
+
+export type SumContextValues = {
+  possibleNums: number[];
+  num1: number | null;
+  num2: AnswerButton;
+  baseNum: number;
+  op1: Operator1;
+  op2: string;
+  rightWrong: boolean | null;
+  setPossibleNums: StateSetter<SumContextValues['possibleNums']>;
+  setNum1: StateSetter<SumContextValues['num1']>;
+  setNum2: StateSetter<SumContextValues['num2']>;
+  setBaseNum: StateSetter<SumContextValues['baseNum']>;
+  setOp1: StateSetter<SumContextValues['op1']>;
+  setOp2: StateSetter<SumContextValues['op2']>;
+  setRightWrong: StateSetter<SumContextValues['rightWrong']>;
+};
 
 export interface AppState {
   showSplash: boolean;
@@ -53,46 +98,3 @@ export interface DefineSumResult {
   possibleAns: AppState['possibleAns'];
   answer1: AppState['correctAns'];
 }
-
-// CONTEXT TYPES
-export type Props = { children: ReactNode };
-
-export type AnswerContextValues = {
-  possibleAns: AppState['possibleAns'];
-  correctAns: AppState['correctAns'];
-  setPossibleAns: React.Dispatch<React.SetStateAction<AppState['possibleAns']>>;
-  setCorrectAns: React.Dispatch<React.SetStateAction<AppState['correctAns']>>;
-};
-
-export type StatusContextValues = {
-  gameStatus: GameStates;
-  showSplash: AppState['showSplash'];
-  setGameStatus: React.Dispatch<React.SetStateAction<GameStates>>;
-  setShowSplash: React.Dispatch<React.SetStateAction<AppState['showSplash']>>;
-};
-
-export type SumContextValues = {
-  possibleNums: AppState['possibleNums'];
-  num1: AppState['num1'];
-  num2: AppState['num2'];
-  baseNum: AppState['baseNum'];
-  op1: AppState['op1'];
-  op2: AppState['op2'];
-  rightWrong: AppState['rightWrong'];
-  setPossibleNums: React.Dispatch<React.SetStateAction<AppState['possibleNums']>>;
-  setNum1: React.Dispatch<React.SetStateAction<AppState['num1']>>;
-  setNum2: React.Dispatch<React.SetStateAction<AppState['num2']>>;
-  setBaseNum: React.Dispatch<React.SetStateAction<AppState['baseNum']>>;
-  setOp1: React.Dispatch<React.SetStateAction<AppState['op1']>>;
-  setOp2: React.Dispatch<React.SetStateAction<AppState['op2']>>;
-  setRightWrong: React.Dispatch<React.SetStateAction<AppState['rightWrong']>>;
-};
-
-export type ScoreContextValues = {
-  totalLives: AppState['totalLives'];
-  livesLeft: AppState['livesLeft'];
-  score: AppState['score'];
-  setTotalLives: React.Dispatch<React.SetStateAction<number>>;
-  setLivesLeft: React.Dispatch<React.SetStateAction<number>>;
-  setScore: React.Dispatch<React.SetStateAction<number>>;
-};

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -69,10 +69,8 @@ export interface AnswerMethodsObj {
   [key: string]: AnswerMethod;
 }
 
-// @to-do: look into generics to get round use of any here
-/* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
-export type GenericFunc = (arg0: any) => void;
-export type OptionsMap<T extends string | number> = T[];
+export type GenericFunc<T> = (arg0: T) => void;
+export type OptionsMap<T> = T[];
 
 export interface DefineSumResult {
   randomNum: SumState['num1'];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -72,6 +72,7 @@ export interface AnswerMethodsObj {
 // @to-do: look into generics to get round use of any here
 /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
 export type GenericFunc = (arg0: any) => void;
+export type OptionsMap<T extends string | number> = T[];
 
 export interface DefineSumResult {
   randomNum: SumState['num1'];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -59,23 +59,6 @@ export type SumState = {
   setRightWrong: StateSetter<SumState['rightWrong']>;
 };
 
-export interface AppState {
-  showSplash: boolean;
-  gameStatus: GameStates;
-  possibleNums: number[];
-  baseNum: number;
-  num1: number | null;
-  num2: AnswerButton;
-  op1: Operator1;
-  op2: string;
-  possibleAns: number[];
-  correctAns: number | null;
-  rightWrong: boolean | null;
-  score: number;
-  totalLives: number;
-  livesLeft: number;
-}
-
 interface AnswerMethod {
   (a: number, b: number): number;
 }
@@ -94,7 +77,7 @@ export interface SettingsPayload {
 export type GenericFunc = (arg0: any) => void;
 
 export interface DefineSumResult {
-  randomNum: AppState['num1'];
-  possibleAns: AppState['possibleAns'];
-  answer1: AppState['correctAns'];
+  randomNum: SumState['num1'];
+  possibleAns: AnswerState['possibleAns'];
+  answer1: AnswerState['correctAns'];
 }


### PR DESCRIPTION
### Bit of refactoring before adding in new features
- Rework the types in `types.ts` so that the state types no longer reference one big block of AppState, but are separated out according to the Context files. (Taking out one level of referencing. Means a lot of changing names of references throughout the site.
- Use generics to get round places where an `any` type had previously been used.
- Refactor some functions to get rid of loops, replace with functions based on  `Array.from`. Reinstate linting rule that disallows the `++` operator.
- Break up larger functions into smaller reusable parts