### PR TITLE
Add saving settings

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -8,12 +8,13 @@ import { useStatus } from '../../context/StatusContext';
 import { SumProvider } from '../../context/SumContext';
 import { ScoreProvider } from '../../context/ScoreContext';
 import { AnswerProvider } from '../../context/AnswerContext';
+import { getSavedSettings } from '../../helpers/helpers';
 
 const App: React.FC = () => {
   const { gameStatus, showSplash, setGameStatus, setShowSplash, setSavedSettings } = useStatus();
 
   useEffect(() => {
-    if (window.localStorage.getItem('sevenStarSettings') !== null) {
+    if (getSavedSettings() !== null) {
       setSavedSettings(true);
       return;
     }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -12,15 +12,16 @@ import { getSavedSettings } from '../../helpers/helpers';
 
 const App: React.FC = () => {
   const { gameStatus, showSplash, setGameStatus, setShowSplash, setSavedSettings } = useStatus();
+  const localSettings = getSavedSettings();
 
   useEffect(() => {
-    if (getSavedSettings() !== null) {
+    if (localSettings) {
       setSavedSettings(true);
       return;
     }
     setShowSplash(false);
     setGameStatus('showSettings');
-  }, []);
+  }, [localSettings, setSavedSettings, setShowSplash, setGameStatus]);
 
   return (
     <div className="App">

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -23,11 +23,12 @@ const App: React.FC = () => {
 
   return (
     <div className="App">
-      {showSplash && <Splashscreen />}
-      <Header />
       <SumProvider>
-        <div className="stage">
-          <ScoreProvider>
+        <ScoreProvider>
+          {showSplash && <Splashscreen />}
+          <Header />
+
+          <div className="stage">
             {gameStatus === 'showSettings' ? (
               <SettingsSheet />
             ) : (
@@ -35,8 +36,8 @@ const App: React.FC = () => {
                 <GameSheet />
               </AnswerProvider>
             )}
-          </ScoreProvider>
-        </div>
+          </div>
+        </ScoreProvider>
       </SumProvider>
     </div>
   );

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -8,20 +8,20 @@ import { useStatus } from '../../context/StatusContext';
 import { SumProvider } from '../../context/SumContext';
 import { ScoreProvider } from '../../context/ScoreContext';
 import { AnswerProvider } from '../../context/AnswerContext';
-import { getSavedSettings } from '../../helpers/helpers';
+import { getLocalSettings } from '../../helpers/helpers';
 
 const App: React.FC = () => {
-  const { gameStatus, showSplash, setGameStatus, setShowSplash, setSavedSettings } = useStatus();
-  const localSettings = getSavedSettings();
+  const { gameStatus, showSplash, setGameStatus, setShowSplash, setIsLocalSettings } = useStatus();
+  const localSettings = getLocalSettings();
 
   useEffect(() => {
     if (localSettings) {
-      setSavedSettings(true);
+      setIsLocalSettings(true);
       return;
     }
     setShowSplash(false);
     setGameStatus('showSettings');
-  }, [localSettings, setSavedSettings, setShowSplash, setGameStatus]);
+  }, [localSettings, setIsLocalSettings, setShowSplash, setGameStatus]);
 
   return (
     <div className="App">

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import './App.css';
 import Header from '../Header/Header';
 import GameSheet from '../GameSheet/GameSheet';
@@ -10,7 +10,13 @@ import { ScoreProvider } from '../../context/ScoreContext';
 import { AnswerProvider } from '../../context/AnswerContext';
 
 const App: React.FC = () => {
-  const { gameStatus, showSplash } = useStatus();
+  const { gameStatus, showSplash, setSavedSettings } = useStatus();
+
+  useEffect(() => {
+    if (window.localStorage.getItem('sevenStarSettings') !== null) {
+      setSavedSettings(true);
+    }
+  });
 
   return (
     <div className="App">

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -10,12 +10,15 @@ import { ScoreProvider } from '../../context/ScoreContext';
 import { AnswerProvider } from '../../context/AnswerContext';
 
 const App: React.FC = () => {
-  const { gameStatus, showSplash, setSavedSettings } = useStatus();
+  const { gameStatus, showSplash, setGameStatus, setShowSplash, setSavedSettings } = useStatus();
 
   useEffect(() => {
     if (window.localStorage.getItem('sevenStarSettings') !== null) {
       setSavedSettings(true);
+      return;
     }
+    setShowSplash(false);
+    setGameStatus('showSettings');
   });
 
   return (

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -20,7 +20,7 @@ const App: React.FC = () => {
     }
     setShowSplash(false);
     setGameStatus('showSettings');
-  });
+  }, []);
 
   return (
     <div className="App">
@@ -28,7 +28,6 @@ const App: React.FC = () => {
         <ScoreProvider>
           {showSplash && <Splashscreen />}
           <Header />
-
           <div className="stage">
             {gameStatus === 'showSettings' ? (
               <SettingsSheet />

--- a/src/components/GameSheet/GameSheet.tsx
+++ b/src/components/GameSheet/GameSheet.tsx
@@ -18,7 +18,7 @@ const GameSheet: React.FC = () => {
   const { totalLives, setLivesLeft, setScore } = useScore();
 
   const resetGameStatus = gameStatus === 'resetGame';
-  const startGameStatus = gameStatus === 'startGame';
+  const defineNumsStatus = gameStatus === 'defineNums';
   const defineSumStatus = gameStatus === 'defineSum';
 
   useEffect(() => {
@@ -27,17 +27,17 @@ const GameSheet: React.FC = () => {
       setRightWrong(null);
       setScore(0);
       setLivesLeft(totalLives);
-      setGameStatus('startGame');
+      setGameStatus('defineNums');
     }
   }, [resetGameStatus, setPossibleNums, setRightWrong, setScore, setLivesLeft, totalLives, setGameStatus]);
 
   useEffect(() => {
-    if (startGameStatus) {
+    if (defineNumsStatus) {
       const newNums = definePossibleNums(baseNum, op1);
       setPossibleNums([...possibleNums].concat(newNums));
       setGameStatus('defineSum');
     }
-  }, [startGameStatus, setGameStatus, baseNum, op1, possibleNums, setPossibleNums]);
+  }, [defineNumsStatus, setGameStatus, baseNum, op1, possibleNums, setPossibleNums]);
 
   useEffect(() => {
     if (defineSumStatus) {

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -26,6 +26,7 @@ const SettingsSheet: React.FC = () => {
       setPanelBaseNum(localSettings.finalBaseNum);
       setDifficulty(localSettings.finalDifficulty);
     }
+    // eslint-disable-next-line
   }, []);
 
   // PANEL HANDLERS START

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -5,10 +5,10 @@ import { GenericFunc, OptionsMap, SumState } from '../../types/types';
 import { useStatus } from '../../context/StatusContext';
 import { useSum } from '../../context/SumContext';
 import { useScore } from '../../context/ScoreContext';
-import { getSavedSettings } from '../../helpers/helpers';
+import { getLocalSettings } from '../../helpers/helpers';
 
 const SettingsSheet: React.FC = () => {
-  const { savedSettings, setGameStatus } = useStatus();
+  const { isLocalSettings, setGameStatus } = useStatus();
   const { setBaseNum, setOp1 } = useSum();
   const { setTotalLives } = useScore();
   const [settingStatus, setSettingStatus] = useState(1);
@@ -16,21 +16,21 @@ const SettingsSheet: React.FC = () => {
   const [panelBaseNum, setPanelBaseNum] = useState(2);
   const [difficulty, setDifficulty] = useState(7);
   const [isResetOperator, setIsResetOperator] = useState(false);
-  const localSettings = getSavedSettings();
+  const localSettings = getLocalSettings();
 
   // IF SETTINGS HAVE ALREADY BEEN SET THEN SHOW ALL OPTIONS FROM START
   useEffect(() => {
-    if (savedSettings && localSettings) {
+    if (isLocalSettings && localSettings) {
       setSettingStatus(4);
       setOperator(localSettings.finalOperator);
       setPanelBaseNum(localSettings.finalBaseNum);
       setDifficulty(localSettings.finalDifficulty);
     }
-  }, [savedSettings, localSettings]);
+  }, []);
 
   // PANEL HANDLERS START
   const panel1Handler: GenericFunc<SumState['op1']> = (chosenOperator) => {
-    if (savedSettings) {
+    if (isLocalSettings) {
       setPanelBaseNum(0);
       setIsResetOperator(true);
     }
@@ -39,7 +39,7 @@ const SettingsSheet: React.FC = () => {
   };
 
   const panel2Handler: GenericFunc<number> = (chosenBaseNum) => {
-    if (!savedSettings || isResetOperator) {
+    if (!isLocalSettings || isResetOperator) {
       setSettingStatus(3);
     }
     setPanelBaseNum(chosenBaseNum);

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -34,27 +34,36 @@ const SettingsSheet: React.FC = () => {
     if (isLocalSettings) {
       setPanelBaseNum(0);
       setIsResetOperator(true);
+      setSettingStatus(4);
+      setOperator(chosenOperator as SumState['op1']);
+      return;
     }
     setSettingStatus(2);
     setOperator(chosenOperator as SumState['op1']);
   };
 
   const panel2Handler: GenericFunc<number> = (chosenBaseNum) => {
-    if (!isLocalSettings || isResetOperator) {
+    if (!isLocalSettings) {
       setSettingStatus(3);
+    }
+    if (isResetOperator) {
+      setSettingStatus(5);
     }
     setPanelBaseNum(chosenBaseNum);
   };
 
   const panel3Handler: GenericFunc<number> = (lives) => {
     setSettingStatus(4);
+    if (isResetOperator) {
+      setSettingStatus(5);
+    }
     setDifficulty(lives);
   };
 
   // PANEL VISIBILITY OPTIONS
   const panel2viz = settingStatus > 1 ? 'show' : 'hide';
-  const panel3viz = settingStatus > 2 ? 'show' : 'hide';
-  const panel4viz = settingStatus > 3 ? 'show' : 'hide';
+  const panel3viz = settingStatus > 2 || isResetOperator ? 'show' : 'hide';
+  const panel4viz = (settingStatus > 3 && !isResetOperator) || settingStatus > 4 ? 'show' : 'hide';
 
   // RENDERING LOGIC
   const bonds = operator === '+';

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -127,6 +127,8 @@ const SettingsSheet: React.FC = () => {
     setOp1(finalOperator);
     setTotalLives(finalDifficulty);
     setGameStatus('resetGame');
+    const allSettings = { finalBaseNum, finalOperator, finalDifficulty };
+    window.localStorage.setItem('sevenStarSettings', JSON.stringify(allSettings));
   };
 
   return (

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -1,28 +1,47 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Button from '../../UI/atoms/Button/Button';
 import './SettingsSheet.css';
 import { GenericFunc, OptionsMap, SumState } from '../../types/types';
 import { useStatus } from '../../context/StatusContext';
 import { useSum } from '../../context/SumContext';
 import { useScore } from '../../context/ScoreContext';
+import { getSavedSettings } from '../../helpers/helpers';
 
 const SettingsSheet: React.FC = () => {
-  const { setGameStatus } = useStatus();
+  const { savedSettings, setGameStatus } = useStatus();
   const { setBaseNum, setOp1 } = useSum();
   const { setTotalLives } = useScore();
   const [settingStatus, setSettingStatus] = useState(1);
   const [operator, setOperator] = useState('+' as SumState['op1']);
   const [panelBaseNum, setPanelBaseNum] = useState(2);
   const [difficulty, setDifficulty] = useState(7);
+  const [isResetOperator, setIsResetOperator] = useState(false);
+  const localSettings = getSavedSettings();
+
+  // IF SETTINGS HAVE ALREADY BEEN SET THEN SHOW ALL OPTIONS FROM START
+  useEffect(() => {
+    if (savedSettings && localSettings) {
+      setSettingStatus(4);
+      setOperator(localSettings.finalOperator);
+      setPanelBaseNum(localSettings.finalBaseNum);
+      setDifficulty(localSettings.finalDifficulty);
+    }
+  }, []);
 
   // PANEL HANDLERS START
   const panel1Handler: GenericFunc<SumState['op1']> = (chosenOperator) => {
+    if (savedSettings) {
+      setPanelBaseNum(0);
+      setIsResetOperator(true);
+    }
     setSettingStatus(2);
     setOperator(chosenOperator as SumState['op1']);
   };
 
   const panel2Handler: GenericFunc<number> = (chosenBaseNum) => {
-    setSettingStatus(3);
+    if (!savedSettings || isResetOperator) {
+      setSettingStatus(3);
+    }
     setPanelBaseNum(chosenBaseNum);
   };
 
@@ -73,7 +92,7 @@ const SettingsSheet: React.FC = () => {
       (option: string | number | SumState['op1'], index: number): JSX.Element => {
         const [butMod, butModAct, butModInact] = buttonStyle;
         let buttonModifiers = butMod;
-        if (settingStatus > panelNum) {
+        if (settingStatus > panelNum && stateCheck) {
           buttonModifiers = option === stateCheck ? butModAct : butModInact;
         }
         return (

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -26,7 +26,7 @@ const SettingsSheet: React.FC = () => {
       setPanelBaseNum(localSettings.finalBaseNum);
       setDifficulty(localSettings.finalDifficulty);
     }
-  }, []);
+  }, [savedSettings, localSettings]);
 
   // PANEL HANDLERS START
   const panel1Handler: GenericFunc<SumState['op1']> = (chosenOperator) => {

--- a/src/components/Splashscreen/Splashscreen.scss
+++ b/src/components/Splashscreen/Splashscreen.scss
@@ -15,7 +15,7 @@
   max-width: 800px;
   margin: 3vh auto;
   padding: 3vh 3vw;
-  background-color: $light;
+  background-color: $lightest;
   text-align: center;
   border: 10px solid $dark;
   border-radius: 1vh;

--- a/src/components/Splashscreen/Splashscreen.tsx
+++ b/src/components/Splashscreen/Splashscreen.tsx
@@ -4,7 +4,7 @@ import './Splashscreen.css';
 import { useStatus } from '../../context/StatusContext';
 import { useSum } from '../../context/SumContext';
 import { useScore } from '../../context/ScoreContext';
-import { getSavedSettings } from '../../helpers/helpers';
+import { getLocalSettings } from '../../helpers/helpers';
 
 const Splashscreen: React.FC = () => {
   let splash: JSX.Element = <div />;
@@ -13,7 +13,7 @@ const Splashscreen: React.FC = () => {
   const { setBaseNum, setOp1 } = useSum();
   const { setTotalLives, setLivesLeft } = useScore();
 
-  const savedSettings = getSavedSettings();
+  const localSettings = getLocalSettings();
 
   const startSettingsHandler = (): void => {
     setGameStatus('showSettings');
@@ -21,11 +21,11 @@ const Splashscreen: React.FC = () => {
   };
 
   const startGameHandler = (): void => {
-    if (savedSettings) {
-      setBaseNum(savedSettings.finalBaseNum);
-      setOp1(savedSettings.finalOperator);
-      setTotalLives(savedSettings.finalDifficulty);
-      setLivesLeft(savedSettings.finalDifficulty);
+    if (localSettings) {
+      setBaseNum(localSettings.finalBaseNum);
+      setOp1(localSettings.finalOperator);
+      setTotalLives(localSettings.finalDifficulty);
+      setLivesLeft(localSettings.finalDifficulty);
       setGameStatus('defineNums');
       setShowSplash(false);
       return;

--- a/src/components/Splashscreen/Splashscreen.tsx
+++ b/src/components/Splashscreen/Splashscreen.tsx
@@ -56,22 +56,30 @@ const Splashscreen: React.FC = () => {
       break;
     case 'endWin':
       splash = (
-        <div>
+        <>
           <h3>Well done! You&rsquo;ve got seven stars!</h3>
           <Button type="button" handler={resetGameHandler} modifiers={modifiers}>
             Play again!
           </Button>
-        </div>
+          <h4>Or...</h4>
+          <Button type="button" handler={startSettingsHandler} modifiers={modifiers}>
+            Change your settings
+          </Button>
+        </>
       );
       break;
     case 'endLose':
       splash = (
-        <div>
+        <>
           <h3>Unlucky! You&rsquo;ve run out lives...</h3>
           <Button type="button" handler={resetGameHandler} modifiers={modifiers}>
             Try again!
           </Button>
-        </div>
+          <h4>Or...</h4>
+          <Button type="button" handler={startSettingsHandler} modifiers={modifiers}>
+            Change your settings
+          </Button>
+        </>
       );
       break;
     default:

--- a/src/components/Splashscreen/Splashscreen.tsx
+++ b/src/components/Splashscreen/Splashscreen.tsx
@@ -11,7 +11,7 @@ const Splashscreen: React.FC = () => {
   const modifiers = 'horizontal';
   const { gameStatus, setGameStatus, setShowSplash } = useStatus();
   const { setBaseNum, setOp1 } = useSum();
-  const { setTotalLives } = useScore();
+  const { setTotalLives, setLivesLeft } = useScore();
 
   const savedSettings = getSavedSettings();
 
@@ -25,6 +25,7 @@ const Splashscreen: React.FC = () => {
       setBaseNum(savedSettings.finalBaseNum);
       setOp1(savedSettings.finalOperator);
       setTotalLives(savedSettings.finalDifficulty);
+      setLivesLeft(savedSettings.finalDifficulty);
       setGameStatus('defineNums');
       setShowSplash(false);
       return;

--- a/src/components/Splashscreen/Splashscreen.tsx
+++ b/src/components/Splashscreen/Splashscreen.tsx
@@ -2,20 +2,34 @@ import React from 'react';
 import Button from '../../UI/atoms/Button/Button';
 import './Splashscreen.css';
 import { useStatus } from '../../context/StatusContext';
+import { useSum } from '../../context/SumContext';
+import { useScore } from '../../context/ScoreContext';
 
 const Splashscreen: React.FC = () => {
   let splash: JSX.Element = <div />;
   const modifiers = 'horizontal';
   const { gameStatus, setGameStatus, setShowSplash } = useStatus();
+  const { setBaseNum, setOp1 } = useSum();
+  const { setTotalLives } = useScore();
 
-  const startGameHandler = (): void => {
-    setGameStatus('startGame');
-    setShowSplash(false);
-  };
+  const savedSettings = window.localStorage.getItem('sevenStarSettings');
 
   const startSettingsHandler = (): void => {
     setGameStatus('showSettings');
     setShowSplash(false);
+  };
+
+  const startGameHandler = (): void => {
+    if (savedSettings) {
+      const parsedSettings = JSON.parse(savedSettings);
+      setBaseNum(parsedSettings.finalBaseNum);
+      setOp1(parsedSettings.finalOperator);
+      setTotalLives(parsedSettings.finalDifficulty);
+      setGameStatus('defineNums');
+      setShowSplash(false);
+      return;
+    }
+    startSettingsHandler(); // Should never need this, but is a failsafe
   };
 
   const resetGameHandler = (): void => {

--- a/src/components/Splashscreen/Splashscreen.tsx
+++ b/src/components/Splashscreen/Splashscreen.tsx
@@ -4,6 +4,7 @@ import './Splashscreen.css';
 import { useStatus } from '../../context/StatusContext';
 import { useSum } from '../../context/SumContext';
 import { useScore } from '../../context/ScoreContext';
+import { getSavedSettings } from '../../helpers/helpers';
 
 const Splashscreen: React.FC = () => {
   let splash: JSX.Element = <div />;
@@ -12,7 +13,7 @@ const Splashscreen: React.FC = () => {
   const { setBaseNum, setOp1 } = useSum();
   const { setTotalLives } = useScore();
 
-  const savedSettings = window.localStorage.getItem('sevenStarSettings');
+  const savedSettings = getSavedSettings();
 
   const startSettingsHandler = (): void => {
     setGameStatus('showSettings');
@@ -21,10 +22,9 @@ const Splashscreen: React.FC = () => {
 
   const startGameHandler = (): void => {
     if (savedSettings) {
-      const parsedSettings = JSON.parse(savedSettings);
-      setBaseNum(parsedSettings.finalBaseNum);
-      setOp1(parsedSettings.finalOperator);
-      setTotalLives(parsedSettings.finalDifficulty);
+      setBaseNum(savedSettings.finalBaseNum);
+      setOp1(savedSettings.finalOperator);
+      setTotalLives(savedSettings.finalDifficulty);
       setGameStatus('defineNums');
       setShowSplash(false);
       return;

--- a/src/components/Splashscreen/Splashscreen.tsx
+++ b/src/components/Splashscreen/Splashscreen.tsx
@@ -13,6 +13,11 @@ const Splashscreen: React.FC = () => {
     setShowSplash(false);
   };
 
+  const startSettingsHandler = (): void => {
+    setGameStatus('showSettings');
+    setShowSplash(false);
+  };
+
   const resetGameHandler = (): void => {
     setGameStatus('resetGame');
     setShowSplash(false);
@@ -21,9 +26,17 @@ const Splashscreen: React.FC = () => {
   switch (gameStatus) {
     case 'startGame':
       splash = (
-        <Button type="button" handler={startGameHandler} modifiers={modifiers}>
-          Start the sums!
-        </Button>
+        <>
+          <h3>Hello!</h3>
+          <h4>Do you want to...</h4>
+          <Button type="button" handler={startGameHandler} modifiers={modifiers}>
+            Use your previous settings?
+          </Button>
+          <h4>Or...</h4>
+          <Button type="button" handler={startSettingsHandler} modifiers={modifiers}>
+            Choose a new type of sum?
+          </Button>
+        </>
       );
       break;
     case 'endWin':

--- a/src/context/StatusContext.tsx
+++ b/src/context/StatusContext.tsx
@@ -7,33 +7,33 @@ const { Provider } = StatusContext;
 const StatusProvider = ({ children }: Props): JSX.Element => {
   const [gameStatus, setGameStatus] = useState('startGame' as GameStates);
   const [showSplash, setShowSplash] = useState(true);
-  const [savedSettings, setSavedSettings] = useState(false);
+  const [isLocalSettings, setIsLocalSettings] = useState(false);
 
   const statusState = useMemo(
-    () => ({ gameStatus, showSplash, savedSettings, setGameStatus, setShowSplash, setSavedSettings }),
-    [gameStatus, showSplash, savedSettings]
+    () => ({ gameStatus, showSplash, isLocalSettings, setGameStatus, setShowSplash, setIsLocalSettings }),
+    [gameStatus, showSplash, isLocalSettings]
   );
 
   return <Provider value={statusState}>{children}</Provider>;
 };
 
 const useStatus = (): StatusState => {
-  const { gameStatus, showSplash, savedSettings, setGameStatus, setShowSplash, setSavedSettings } = useContext(
+  const { gameStatus, showSplash, isLocalSettings, setGameStatus, setShowSplash, setIsLocalSettings } = useContext(
     StatusContext
   );
 
   if (
     gameStatus === undefined ||
     showSplash === undefined ||
-    savedSettings === undefined ||
+    isLocalSettings === undefined ||
     setGameStatus === undefined ||
     setShowSplash === undefined ||
-    setSavedSettings === undefined
+    setIsLocalSettings === undefined
   ) {
     throw new Error('useStatus must be used within a StatusProvider');
   }
 
-  return { gameStatus, showSplash, savedSettings, setGameStatus, setShowSplash, setSavedSettings };
+  return { gameStatus, showSplash, isLocalSettings, setGameStatus, setShowSplash, setIsLocalSettings };
 };
 
 export { StatusProvider, useStatus };

--- a/src/context/StatusContext.tsx
+++ b/src/context/StatusContext.tsx
@@ -5,8 +5,8 @@ const StatusContext = React.createContext<Partial<StatusState>>({ gameStatus: 's
 const { Provider } = StatusContext;
 
 const StatusProvider = ({ children }: Props): JSX.Element => {
-  const [gameStatus, setGameStatus] = useState('showSettings' as GameStates);
-  const [showSplash, setShowSplash] = useState(false);
+  const [gameStatus, setGameStatus] = useState('startGame' as GameStates);
+  const [showSplash, setShowSplash] = useState(true);
   const [savedSettings, setSavedSettings] = useState(false);
 
   const statusState = useMemo(

--- a/src/context/StatusContext.tsx
+++ b/src/context/StatusContext.tsx
@@ -7,28 +7,33 @@ const { Provider } = StatusContext;
 const StatusProvider = ({ children }: Props): JSX.Element => {
   const [gameStatus, setGameStatus] = useState('showSettings' as GameStates);
   const [showSplash, setShowSplash] = useState(false);
+  const [savedSettings, setSavedSettings] = useState(false);
 
-  const statusState = useMemo(() => ({ gameStatus, showSplash, setGameStatus, setShowSplash }), [
-    gameStatus,
-    showSplash
-  ]);
+  const statusState = useMemo(
+    () => ({ gameStatus, showSplash, savedSettings, setGameStatus, setShowSplash, setSavedSettings }),
+    [gameStatus, showSplash, savedSettings]
+  );
 
   return <Provider value={statusState}>{children}</Provider>;
 };
 
 const useStatus = (): StatusState => {
-  const { gameStatus, showSplash, setGameStatus, setShowSplash } = useContext(StatusContext);
+  const { gameStatus, showSplash, savedSettings, setGameStatus, setShowSplash, setSavedSettings } = useContext(
+    StatusContext
+  );
 
   if (
     gameStatus === undefined ||
     showSplash === undefined ||
+    savedSettings === undefined ||
     setGameStatus === undefined ||
-    setShowSplash === undefined
+    setShowSplash === undefined ||
+    setSavedSettings === undefined
   ) {
     throw new Error('useStatus must be used within a StatusProvider');
   }
 
-  return { gameStatus, showSplash, setGameStatus, setShowSplash };
+  return { gameStatus, showSplash, savedSettings, setGameStatus, setShowSplash, setSavedSettings };
 };
 
 export { StatusProvider, useStatus };

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,4 +1,4 @@
-import { SumState, AnswerMethodsObj, DefineSumResult } from '../types/types';
+import { SumState, SettingsModel, AnswerMethodsObj, DefineSumResult } from '../types/types';
 
 // fn retuns a random integer with a ceiling based on the number given
 export const getRandomNumber = (base: number): number => {
@@ -62,4 +62,12 @@ export const defineSum = (
   const possibleAns = [...answerSet].map((x) => answerArray[x]);
 
   return { randomNum, possibleAns, answer1 };
+};
+
+export const getSavedSettings = (): SettingsModel | null => {
+  const localSettings = window.localStorage.getItem('sevenStarSettings');
+  if (localSettings) {
+    return JSON.parse(localSettings);
+  }
+  return null;
 };

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -64,7 +64,7 @@ export const defineSum = (
   return { randomNum, possibleAns, answer1 };
 };
 
-export const getSavedSettings = (): SettingsModel | null => {
+export const getLocalSettings = (): SettingsModel | null => {
   const localSettings = window.localStorage.getItem('sevenStarSettings');
   if (localSettings) {
     return JSON.parse(localSettings);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -5,6 +5,7 @@ import { ReactNode } from 'react';
 export type GameStates =
   | 'startGame'
   | 'showSettings'
+  | 'defineNums'
   | 'defineSum'
   | 'resetGame'
   | 'showSum'

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -39,10 +39,10 @@ export type ScoreState = {
 export type StatusState = {
   gameStatus: GameStates;
   showSplash: boolean;
-  savedSettings: boolean;
+  isLocalSettings: boolean;
   setGameStatus: StateSetter<StatusState['gameStatus']>;
   setShowSplash: StateSetter<StatusState['showSplash']>;
-  setSavedSettings: StateSetter<StatusState['savedSettings']>;
+  setIsLocalSettings: StateSetter<StatusState['isLocalSettings']>;
 };
 
 export type SumState = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -38,8 +38,10 @@ export type ScoreState = {
 export type StatusState = {
   gameStatus: GameStates;
   showSplash: boolean;
+  savedSettings: boolean;
   setGameStatus: StateSetter<StatusState['gameStatus']>;
   setShowSplash: StateSetter<StatusState['showSplash']>;
+  setSavedSettings: StateSetter<StatusState['savedSettings']>;
 };
 
 export type SumState = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -62,6 +62,12 @@ export type SumState = {
   setRightWrong: StateSetter<SumState['rightWrong']>;
 };
 
+export interface SettingsModel {
+  finalBaseNum: number;
+  finalOperator: SumState['op1'];
+  finalDifficulty: number;
+}
+
 // METHOD AND FUNCTION TYPES
 
 interface AnswerMethod {


### PR DESCRIPTION
Add ability to:
- save settings to local storage
- when game starts, if settings are available, user has the choice to play with the same settings as last time or change them
- if settings have been set, user has the ability to see and change all settings immediately
- user has the option to change settings at the end of a game

Preview:
https://deploy-preview-16--seven-star-sums.netlify.app/