### PR TITLE
Add more sum types

### DIFF
--- a/src/components/GameSheet/Check/Check.tsx
+++ b/src/components/GameSheet/Check/Check.tsx
@@ -14,10 +14,10 @@ const Check: React.FC = (): JSX.Element => {
   const { wrongAnswers, setLivesLeft, setScore, setWrongAnswers } = useScore();
 
   const yesButtonHandler = (): void => {
-    const correct = num2 === correctAns;
-    setRightWrong(correct);
+    const isCorrect = num2 === correctAns;
+    setRightWrong(isCorrect);
     setGameStatus('showResult');
-    if (!correct) {
+    if (!isCorrect) {
       setLivesLeft((prevLives) => prevLives - 1);
       setWrongAnswers([
         ...wrongAnswers,

--- a/src/components/GameSheet/Check/Check.tsx
+++ b/src/components/GameSheet/Check/Check.tsx
@@ -6,11 +6,12 @@ import { useStatus } from '../../../context/StatusContext';
 import { useAnswer } from '../../../context/AnswerContext';
 import { useSum } from '../../../context/SumContext';
 import { useScore } from '../../../context/ScoreContext';
+import { getSumNumberOrder } from '../../../helpers/helpers';
 
 const Check: React.FC = (): JSX.Element => {
   const { setGameStatus } = useStatus();
   const { correctAns } = useAnswer();
-  const { num2, setNum2, setRightWrong } = useSum();
+  const { op1, num1, num2, baseNum, setNum2, setRightWrong } = useSum();
   const { wrongAnswers, setLivesLeft, setScore, setWrongAnswers } = useScore();
 
   const yesButtonHandler = (): void => {
@@ -19,11 +20,14 @@ const Check: React.FC = (): JSX.Element => {
     setGameStatus('showResult');
     if (!isCorrect) {
       setLivesLeft((prevLives) => prevLives - 1);
+      const sumOrder = getSumNumberOrder(op1, num1, correctAns as number, baseNum);
+      const sum = `${sumOrder[0]} ${op1} ${sumOrder[1]} = ${sumOrder[2]}`;
       setWrongAnswers([
         ...wrongAnswers,
         {
           correctAnswer: correctAns,
-          playerAnswer: num2
+          playerAnswer: num2,
+          completeSum: sum
         }
       ]);
       return;

--- a/src/components/GameSheet/GameSheet.tsx
+++ b/src/components/GameSheet/GameSheet.tsx
@@ -13,7 +13,7 @@ import { definePossibleNums, defineSum } from '../../helpers/helpers';
 
 const GameSheet: React.FC = () => {
   const { gameStatus, setGameStatus } = useStatus();
-  const { baseNum, op1, possibleNums, setNum1, setNum2, setPossibleNums, setRightWrong } = useSum();
+  const { sumType, baseNum, op1, possibleNums, setNum1, setNum2, setPossibleNums, setRightWrong } = useSum();
   const { setPossibleAns, setCorrectAns } = useAnswer();
   const { totalLives, setLivesLeft, setScore, setWrongAnswers } = useScore();
 
@@ -43,15 +43,15 @@ const GameSheet: React.FC = () => {
 
   useEffect(() => {
     if (defineNumsStatus) {
-      const newNums = definePossibleNums(baseNum, op1);
+      const newNums = definePossibleNums(baseNum, sumType);
       setPossibleNums([...possibleNums].concat(newNums));
       setGameStatus('defineSum');
     }
-  }, [defineNumsStatus, setGameStatus, baseNum, op1, possibleNums, setPossibleNums]);
+  }, [defineNumsStatus, setGameStatus, baseNum, sumType, possibleNums, setPossibleNums]);
 
   useEffect(() => {
     if (defineSumStatus) {
-      const newSum = defineSum(possibleNums, baseNum, op1);
+      const newSum = defineSum(sumType, possibleNums, baseNum, op1);
       setNum1(newSum.randomNum);
       setNum2('?');
       setPossibleNums([...possibleNums].filter((val) => val !== newSum.randomNum));
@@ -62,6 +62,7 @@ const GameSheet: React.FC = () => {
   }, [
     defineSumStatus,
     setGameStatus,
+    sumType,
     baseNum,
     op1,
     possibleNums,

--- a/src/components/GameSheet/Sum/Sum.tsx
+++ b/src/components/GameSheet/Sum/Sum.tsx
@@ -2,27 +2,27 @@ import React from 'react';
 import './Sum.css';
 import '../../../UI/atoms/Button/Button.css';
 import { useSum } from '../../../context/SumContext';
+import { getSumNumberOrder } from '../../../helpers/helpers';
 
 const Sum: React.FC = () => {
-  const { num1, num2, op1, op2, baseNum, rightWrong } = useSum();
+  const { sumType, num1, num2, op1, op2, baseNum, rightWrong } = useSum();
   let borderColour: string;
   if (rightWrong === null || num2 === '?') {
     borderColour = '';
   } else {
     borderColour = rightWrong ? 'border-green' : 'border-red';
   }
-  const bonds = op1 === '+';
-  const circle2 = bonds ? num2 : baseNum;
-  const circle3 = bonds ? baseNum : num2;
+  const bonds = sumType === 'bonds';
+  const sumOrder = getSumNumberOrder(op1, num1, num2, baseNum);
   const circle2Styles = bonds ? `btn--round btn--round-large ${borderColour}` : 'btn--round btn--round-large';
   const circle3Styles = bonds ? 'btn--round btn--round-large' : `btn--round btn--round-large ${borderColour}`;
   return (
     <div className="container sum-container">
-      <div className="btn--round btn--round-large">{num1}</div>
+      <div className="btn--round btn--round-large">{sumOrder[0]}</div>
       <div className="btn--round btn--round-small">{op1}</div>
-      <div className={circle2Styles}>{circle2}</div>
+      <div className={circle2Styles}>{sumOrder[1]}</div>
       <div className="btn--round btn--round-small">{op2}</div>
-      <div className={circle3Styles}>{circle3}</div>
+      <div className={circle3Styles}>{sumOrder[2]}</div>
     </div>
   );
 };

--- a/src/components/GameSheet/Sum/Sum.tsx
+++ b/src/components/GameSheet/Sum/Sum.tsx
@@ -5,7 +5,7 @@ import { useSum } from '../../../context/SumContext';
 import { getSumNumberOrder } from '../../../helpers/helpers';
 
 const Sum: React.FC = () => {
-  const { sumType, num1, num2, op1, op2, baseNum, rightWrong } = useSum();
+  const { sumType, num1, num2, op1, baseNum, rightWrong } = useSum();
   let borderColour: string;
   if (rightWrong === null || num2 === '?') {
     borderColour = '';
@@ -21,7 +21,7 @@ const Sum: React.FC = () => {
       <div className="btn--round btn--round-large">{sumOrder[0]}</div>
       <div className="btn--round btn--round-small">{op1}</div>
       <div className={circle2Styles}>{sumOrder[1]}</div>
-      <div className="btn--round btn--round-small">{op2}</div>
+      <div className="btn--round btn--round-small">=</div>
       <div className={circle3Styles}>{sumOrder[2]}</div>
     </div>
   );

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -12,7 +12,7 @@ const SettingsSheet: React.FC = () => {
   const { setBaseNum, setOp1 } = useSum();
   const { setTotalLives } = useScore();
   const [settingStatus, setSettingStatus] = useState(1);
-  const [sumType, setSumType] = useState('bond');
+  const [sumType, setSumType] = useState('bonds');
   const [operator, setOperator] = useState('+' as SumState['op1']);
   const [panelBaseNum, setPanelBaseNum] = useState(2);
   const [difficulty, setDifficulty] = useState(7);
@@ -26,6 +26,9 @@ const SettingsSheet: React.FC = () => {
       setOperator(localSettings.finalOperator);
       setPanelBaseNum(localSettings.finalBaseNum);
       setDifficulty(localSettings.finalDifficulty);
+      if (localSettings.finalOperator === 'x') {
+        setSumType('tables');
+      }
     }
     // eslint-disable-next-line
   }, []);
@@ -68,7 +71,7 @@ const SettingsSheet: React.FC = () => {
   const panel5viz = (settingStatus > 4 && !isResetOperator) || settingStatus > 5 ? 'show' : 'hide';
 
   // RENDERING LOGIC
-  const bonds = operator === '+';
+  const bonds = sumType === 'bonds';
 
   // BUTTON STYLING
   const horizButtons = ['horizontal'];
@@ -84,8 +87,9 @@ const SettingsSheet: React.FC = () => {
   };
 
   // BUTTON CONTENT
+  const typeOptions = ['bonds', 'tables'];
+  const typeText = ['Number bonds', 'Times tables'];
   const operatorOptions = ['+', 'x'];
-  const operatorText = ['Number bonds', 'Times tables'];
   const tableOptions = [2, 3, 4, 5, 8, 10];
   const bondOptions = [10, 20];
   const difficultyOptions = [7, 5, 3];
@@ -120,14 +124,7 @@ const SettingsSheet: React.FC = () => {
       }
     );
 
-  const operatorMap = buttonMap(
-    operatorOptions,
-    operator,
-    1,
-    panel1Handler,
-    makeButtonStyles(horizButtons),
-    operatorText
-  );
+  const operatorMap = buttonMap(typeOptions, sumType, 1, panel1Handler, makeButtonStyles(horizButtons), typeText);
   const bondMap = buttonMap(
     bondOptions,
     panelBaseNum,

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -12,7 +12,7 @@ const SettingsSheet: React.FC = () => {
   const { setBaseNum, setOp1 } = useSum();
   const { setTotalLives } = useScore();
   const [settingStatus, setSettingStatus] = useState(1);
-  const [sumType, setSumType] = useState('bonds');
+  const [panelSumType, setPanelSumType] = useState('bonds');
   const [operator, setOperator] = useState('+' as SumState['op1']);
   const [panelBaseNum, setPanelBaseNum] = useState(2);
   const [difficulty, setDifficulty] = useState(7);
@@ -27,7 +27,7 @@ const SettingsSheet: React.FC = () => {
       setPanelBaseNum(localSettings.finalBaseNum);
       setDifficulty(localSettings.finalDifficulty);
       if (localSettings.finalOperator === 'x') {
-        setSumType('tables');
+        setPanelSumType('tables');
       }
     }
     // eslint-disable-next-line
@@ -39,11 +39,11 @@ const SettingsSheet: React.FC = () => {
       setPanelBaseNum(0);
       setIsResetOperator(true);
       setSettingStatus(5);
-      setSumType(chosenType);
+      setPanelSumType(chosenType);
       return;
     }
     setSettingStatus(2);
-    setSumType(chosenType);
+    setPanelSumType(chosenType);
   };
 
   const panel2Handler: GenericFunc<SumState['op1']> = (chosenOperator) => {
@@ -78,7 +78,7 @@ const SettingsSheet: React.FC = () => {
   const panel5viz = (settingStatus > 4 && !isResetOperator) || settingStatus > 5 ? 'show' : 'hide';
 
   // RENDERING LOGIC
-  const bonds = sumType === 'bonds';
+  const bonds = panelSumType === 'bonds';
 
   // BUTTON STYLING
   const horizButtons = ['horizontal'];
@@ -132,7 +132,7 @@ const SettingsSheet: React.FC = () => {
       }
     );
 
-  const typeMap = buttonMap(typeOptions, sumType, 1, panel1Handler, makeButtonStyles(horizButtons), typeText);
+  const typeMap = buttonMap(typeOptions, panelSumType, 1, panel1Handler, makeButtonStyles(horizButtons), typeText);
   const bondOperatorMap = buttonMap(
     bondOperatorOptions,
     operator,

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -85,7 +85,7 @@ const SettingsSheet: React.FC = () => {
   const operatorOptions = ['+', 'x'];
   const operatorText = ['Number bonds', 'Times tables'];
   const tableOptions = [2, 3, 4, 5, 8, 10];
-  const pairOptions = [10, 20];
+  const bondOptions = [10, 20];
   const difficultyOptions = [7, 5, 3];
   const difficultyText = ['Medium: 7', 'Hard: 5', ' Very hard: 3'];
 
@@ -126,13 +126,13 @@ const SettingsSheet: React.FC = () => {
     makeButtonStyles(horizButtons),
     operatorText
   );
-  const pairMap = buttonMap(
-    pairOptions,
+  const bondMap = buttonMap(
+    bondOptions,
     panelBaseNum,
     2,
     panel2Handler,
     makeButtonStyles(smallRoundButtons),
-    pairOptions
+    bondOptions
   );
   const tableMap = buttonMap(
     tableOptions,
@@ -170,7 +170,7 @@ const SettingsSheet: React.FC = () => {
         {bonds ? (
           <>
             <h3>Choose your bond number:</h3>
-            <div className="settings__button-container settings__button-container--small">{pairMap}</div>
+            <div className="settings__button-container settings__button-container--small">{bondMap}</div>
           </>
         ) : (
           <>

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -9,10 +9,10 @@ import { getLocalSettings } from '../../helpers/helpers';
 
 const SettingsSheet: React.FC = () => {
   const { isLocalSettings, setGameStatus } = useStatus();
-  const { setBaseNum, setOp1 } = useSum();
+  const { setSumType, setBaseNum, setOp1 } = useSum();
   const { setTotalLives } = useScore();
   const [settingStatus, setSettingStatus] = useState(1);
-  const [panelSumType, setPanelSumType] = useState('bonds');
+  const [panelSumType, setPanelSumType] = useState('bonds' as SumState['sumType']);
   const [operator, setOperator] = useState('+' as SumState['op1']);
   const [panelBaseNum, setPanelBaseNum] = useState(2);
   const [difficulty, setDifficulty] = useState(7);
@@ -39,11 +39,11 @@ const SettingsSheet: React.FC = () => {
       setPanelBaseNum(0);
       setIsResetOperator(true);
       setSettingStatus(5);
-      setPanelSumType(chosenType);
+      setPanelSumType(chosenType as SumState['sumType']);
       return;
     }
     setSettingStatus(2);
-    setPanelSumType(chosenType);
+    setPanelSumType(chosenType as SumState['sumType']);
   };
 
   const panel2Handler: GenericFunc<SumState['op1']> = (chosenOperator) => {
@@ -105,15 +105,15 @@ const SettingsSheet: React.FC = () => {
 
   // CREATE BUTTON MAPS
   const buttonMap = (
-    options: OptionsMap<string | number | SumState['op1']>,
+    options: OptionsMap<string | number | SumState['op1'] | SumState['sumType']>,
     stateCheck: string | number,
     panelNum: number,
-    clickHandler: GenericFunc<SumState['op1'] & number>,
+    clickHandler: GenericFunc<SumState['sumType'] & SumState['op1'] & number>,
     buttonStyle: string[][],
     buttonText: number[] | string[]
   ): JSX.Element[] =>
     options.map(
-      (option: string | number | SumState['op1'], index: number): JSX.Element => {
+      (option: string | number | SumState['op1'] | SumState['sumType'], index: number): JSX.Element => {
         const [butMod, butModAct, butModInact] = buttonStyle;
         let buttonModifiers = butMod;
         if (settingStatus > panelNum && stateCheck) {
@@ -123,7 +123,7 @@ const SettingsSheet: React.FC = () => {
           <Button
             key={`panel-${panelNum}-${option}`}
             type="button"
-            handler={(): void => clickHandler(option as SumState['op1'] & number)}
+            handler={(): void => clickHandler(option as SumState['sumType'] & SumState['op1'] & number)}
             modifiers={buttonModifiers}
           >
             {buttonText[index]}
@@ -174,12 +174,18 @@ const SettingsSheet: React.FC = () => {
     difficultyText
   );
 
-  const finalSettings = (finalBaseNum: number, finalOperator: SumState['op1'], finalDifficulty: number): void => {
+  const finalSettings = (
+    finalSumType: SumState['sumType'],
+    finalBaseNum: number,
+    finalOperator: SumState['op1'],
+    finalDifficulty: number
+  ): void => {
+    setSumType(finalSumType);
     setBaseNum(finalBaseNum);
     setOp1(finalOperator);
     setTotalLives(finalDifficulty);
     setGameStatus('resetGame');
-    const allSettings = { finalBaseNum, finalOperator, finalDifficulty };
+    const allSettings = { finalSumType, finalBaseNum, finalOperator, finalDifficulty };
     window.localStorage.setItem('sevenStarSettings', JSON.stringify(allSettings));
   };
 
@@ -222,7 +228,7 @@ const SettingsSheet: React.FC = () => {
       <div className={`settings__panel settings__panel--2 settings__panel--${panel5viz}`}>
         <Button
           type="button"
-          handler={(): void => finalSettings(panelBaseNum, operator, difficulty)}
+          handler={(): void => finalSettings(panelSumType, panelBaseNum, operator, difficulty)}
           modifiers={horizGreenButtons}
         >
           Start the sums!

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -22,7 +22,7 @@ const SettingsSheet: React.FC = () => {
   // IF SETTINGS HAVE ALREADY BEEN SET THEN SHOW ALL OPTIONS FROM START
   useEffect(() => {
     if (isLocalSettings && localSettings) {
-      setSettingStatus(4);
+      setSettingStatus(5);
       setOperator(localSettings.finalOperator);
       setPanelBaseNum(localSettings.finalBaseNum);
       setDifficulty(localSettings.finalDifficulty);
@@ -35,36 +35,37 @@ const SettingsSheet: React.FC = () => {
     if (isLocalSettings) {
       setPanelBaseNum(0);
       setIsResetOperator(true);
-      setSettingStatus(4);
+      setSettingStatus(5);
       setOperator(chosenOperator as SumState['op1']);
       return;
     }
-    setSettingStatus(2);
+    setSettingStatus(3);
     setOperator(chosenOperator as SumState['op1']);
   };
 
-  const panel2Handler: GenericFunc<number> = (chosenBaseNum) => {
+  const panel3Handler: GenericFunc<number> = (chosenBaseNum) => {
     if (!isLocalSettings) {
-      setSettingStatus(3);
+      setSettingStatus(4);
     }
     if (isResetOperator) {
-      setSettingStatus(5);
+      setSettingStatus(6);
     }
     setPanelBaseNum(chosenBaseNum);
   };
 
-  const panel3Handler: GenericFunc<number> = (lives) => {
-    setSettingStatus(4);
+  const panel4Handler: GenericFunc<number> = (lives) => {
+    setSettingStatus(5);
     if (isResetOperator) {
-      setSettingStatus(5);
+      setSettingStatus(6);
     }
     setDifficulty(lives);
   };
 
   // PANEL VISIBILITY OPTIONS
   const panel2viz = settingStatus > 1 ? 'show' : 'hide';
-  const panel3viz = settingStatus > 2 || isResetOperator ? 'show' : 'hide';
-  const panel4viz = (settingStatus > 3 && !isResetOperator) || settingStatus > 4 ? 'show' : 'hide';
+  const panel3viz = settingStatus > 2 ? 'show' : 'hide';
+  const panel4viz = settingStatus > 3 || isResetOperator ? 'show' : 'hide';
+  const panel5viz = (settingStatus > 4 && !isResetOperator) || settingStatus > 5 ? 'show' : 'hide';
 
   // RENDERING LOGIC
   const bonds = operator === '+';
@@ -130,24 +131,24 @@ const SettingsSheet: React.FC = () => {
   const bondMap = buttonMap(
     bondOptions,
     panelBaseNum,
-    2,
-    panel2Handler,
+    3,
+    panel3Handler,
     makeButtonStyles(smallRoundButtons),
     bondOptions
   );
   const tableMap = buttonMap(
     tableOptions,
     panelBaseNum,
-    2,
-    panel2Handler,
+    3,
+    panel3Handler,
     makeButtonStyles(smallRoundButtons),
     tableOptions
   );
   const difficultyMap = buttonMap(
     difficultyOptions,
     difficulty,
-    3,
-    panel3Handler,
+    4,
+    panel4Handler,
     makeButtonStyles(horizButtons),
     difficultyText
   );
@@ -167,7 +168,7 @@ const SettingsSheet: React.FC = () => {
         <h3>What type of sums do you want to play today?</h3>
         <div className="settings__button-container">{operatorMap}</div>
       </div>
-      <div className="settings__panel settings__panel--1">
+      <div className={`settings__panel settings__panel--1 settings__panel--${panel2viz}`}>
         {bonds ? (
           <>
             <h3>Do you want to do adding or taking away?</h3>
@@ -180,7 +181,7 @@ const SettingsSheet: React.FC = () => {
           </>
         )}
       </div>
-      <div className={`settings__panel settings__panel--2 settings__panel--${panel2viz}`}>
+      <div className={`settings__panel settings__panel--2 settings__panel--${panel3viz}`}>
         {bonds ? (
           <>
             <h3>Choose your bond number:</h3>
@@ -193,11 +194,11 @@ const SettingsSheet: React.FC = () => {
           </>
         )}
       </div>
-      <div className={`settings__panel settings__panel--3 settings__panel--${panel3viz}`}>
+      <div className={`settings__panel settings__panel--3 settings__panel--${panel4viz}`}>
         <h3>How many lives do you want to have?</h3>
         <div className="settings__button-container">{difficultyMap}</div>
       </div>
-      <div className={`settings__panel settings__panel--2 settings__panel--${panel4viz}`}>
+      <div className={`settings__panel settings__panel--2 settings__panel--${panel5viz}`}>
         <Button
           type="button"
           handler={(): void => finalSettings(panelBaseNum, operator, difficulty)}

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -26,9 +26,7 @@ const SettingsSheet: React.FC = () => {
       setOperator(localSettings.finalOperator);
       setPanelBaseNum(localSettings.finalBaseNum);
       setDifficulty(localSettings.finalDifficulty);
-      if (localSettings.finalOperator === 'x') {
-        setPanelSumType('tables');
-      }
+      setPanelSumType(localSettings.finalSumType);
     }
     // eslint-disable-next-line
   }, []);

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -34,15 +34,22 @@ const SettingsSheet: React.FC = () => {
   }, []);
 
   // PANEL HANDLERS START
-  const panel1Handler: GenericFunc<SumState['op1']> = (chosenOperator) => {
+  const panel1Handler: GenericFunc<SumState['op1']> = (chosenType) => {
     if (isLocalSettings) {
       setPanelBaseNum(0);
       setIsResetOperator(true);
       setSettingStatus(5);
-      setOperator(chosenOperator as SumState['op1']);
+      setSumType(chosenType);
       return;
     }
-    setSettingStatus(3);
+    setSettingStatus(2);
+    setSumType(chosenType);
+  };
+
+  const panel2Handler: GenericFunc<SumState['op1']> = (chosenOperator) => {
+    if (!isLocalSettings) {
+      setSettingStatus(3);
+    }
     setOperator(chosenOperator as SumState['op1']);
   };
 
@@ -89,7 +96,8 @@ const SettingsSheet: React.FC = () => {
   // BUTTON CONTENT
   const typeOptions = ['bonds', 'tables'];
   const typeText = ['Number bonds', 'Times tables'];
-  const operatorOptions = ['+', 'x'];
+  const bondOperatorOptions = ['+', '-'];
+  const tableOperatorOptions = ['x', '÷'];
   const tableOptions = [2, 3, 4, 5, 8, 10];
   const bondOptions = [10, 20];
   const difficultyOptions = [7, 5, 3];
@@ -124,7 +132,23 @@ const SettingsSheet: React.FC = () => {
       }
     );
 
-  const operatorMap = buttonMap(typeOptions, sumType, 1, panel1Handler, makeButtonStyles(horizButtons), typeText);
+  const typeMap = buttonMap(typeOptions, sumType, 1, panel1Handler, makeButtonStyles(horizButtons), typeText);
+  const bondOperatorMap = buttonMap(
+    bondOperatorOptions,
+    operator,
+    2,
+    panel2Handler,
+    makeButtonStyles(horizButtons),
+    bondOperatorOptions
+  );
+  const tableOperatorMap = buttonMap(
+    tableOperatorOptions,
+    operator,
+    2,
+    panel2Handler,
+    makeButtonStyles(horizButtons),
+    tableOperatorOptions
+  );
   const bondMap = buttonMap(
     bondOptions,
     panelBaseNum,
@@ -163,18 +187,18 @@ const SettingsSheet: React.FC = () => {
     <div className="settings__sheet">
       <div className="settings__panel settings__panel--1">
         <h3>What type of sums do you want to play today?</h3>
-        <div className="settings__button-container">{operatorMap}</div>
+        <div className="settings__button-container">{typeMap}</div>
       </div>
       <div className={`settings__panel settings__panel--1 settings__panel--${panel2viz}`}>
         {bonds ? (
           <>
             <h3>Do you want to do adding or taking away?</h3>
-            <div className="settings__button-container">{operatorMap}</div>
+            <div className="settings__button-container">{bondOperatorMap}</div>
           </>
         ) : (
           <>
             <h3>Do you want to do multiplication or division?</h3>
-            <div className="settings__button-container">{operatorMap}</div>
+            <div className="settings__button-container">{tableOperatorMap}</div>
           </>
         )}
       </div>

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -12,6 +12,7 @@ const SettingsSheet: React.FC = () => {
   const { setBaseNum, setOp1 } = useSum();
   const { setTotalLives } = useScore();
   const [settingStatus, setSettingStatus] = useState(1);
+  const [sumType, setSumType] = useState('bond');
   const [operator, setOperator] = useState('+' as SumState['op1']);
   const [panelBaseNum, setPanelBaseNum] = useState(2);
   const [difficulty, setDifficulty] = useState(7);
@@ -165,6 +166,19 @@ const SettingsSheet: React.FC = () => {
       <div className="settings__panel settings__panel--1">
         <h3>What type of sums do you want to play today?</h3>
         <div className="settings__button-container">{operatorMap}</div>
+      </div>
+      <div className="settings__panel settings__panel--1">
+        {bonds ? (
+          <>
+            <h3>Do you want to do adding or taking away?</h3>
+            <div className="settings__button-container">{operatorMap}</div>
+          </>
+        ) : (
+          <>
+            <h3>Do you want to do multiplication or division?</h3>
+            <div className="settings__button-container">{operatorMap}</div>
+          </>
+        )}
       </div>
       <div className={`settings__panel settings__panel--2 settings__panel--${panel2viz}`}>
         {bonds ? (

--- a/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/SettingsSheet/SettingsSheet.tsx
@@ -84,10 +84,8 @@ const SettingsSheet: React.FC = () => {
   const smallRoundButtons = ['round', 'round-small', 'round-white-border'];
 
   const makeButtonStyles = (array1: string[]): string[][] => {
-    const array2 = [...array1];
-    array2.push('active');
-    const array3 = [...array1];
-    array3.push('inactive');
+    const array2 = [...array1, 'active'];
+    const array3 = [...array1, 'inactive'];
     return [array1, array2, array3];
   };
 

--- a/src/components/Splashscreen/GameReview/GameReview.tsx
+++ b/src/components/Splashscreen/GameReview/GameReview.tsx
@@ -3,12 +3,9 @@ import './GameReview.css';
 import Heart from '../../../UI/atoms/Icons/Heart';
 import Star from '../../../UI/atoms/Icons/Star';
 import { useScore } from '../../../context/ScoreContext';
-import { useSum } from '../../../context/SumContext';
-import { answerMethod } from '../../../helpers/helpers';
 
 const GameReview: React.FC = () => {
   const { totalLives, livesLeft, score, wrongAnswers } = useScore();
-  const { baseNum, op1 } = useSum();
 
   const lostLives = totalLives - livesLeft;
 
@@ -22,18 +19,10 @@ const GameReview: React.FC = () => {
 
   const wrongSums = didLoseLives
     ? wrongAnswers.map((obj) => {
-        const isAddition = op1 === '+';
-        const missingNum = isAddition
-          ? answerMethod[op1](baseNum, obj.correctAnswer as number)
-          : (obj.correctAnswer as number) / baseNum;
-        const sum = isAddition
-          ? `${missingNum} + ${obj.correctAnswer} = ${baseNum}`
-          : `${missingNum} x ${baseNum} = ${obj.correctAnswer}`;
-
         return (
           <div className="game-review__sum-container" key={`sum-${obj.correctAnswer}`}>
             <p>
-              <span className="game-review__sum">{sum}</span>
+              <span className="game-review__sum">{obj.completeSum}</span>
               &nbsp;&nbsp;&nbsp;You answered&nbsp;
               <span className="game-review__answer game-review__answer--wrong">{obj.playerAnswer}</span>
               ;&nbsp; the correct answer was&nbsp;

--- a/src/components/Splashscreen/Splashscreen.tsx
+++ b/src/components/Splashscreen/Splashscreen.tsx
@@ -12,7 +12,7 @@ const Splashscreen: React.FC = () => {
   let splash: JSX.Element = <div />;
   const modifiers = 'horizontal';
   const { gameStatus, setGameStatus, setShowSplash } = useStatus();
-  const { setBaseNum, setOp1 } = useSum();
+  const { setSumType, setBaseNum, setOp1 } = useSum();
   const { setTotalLives, setLivesLeft } = useScore();
 
   const localSettings = getLocalSettings();
@@ -24,6 +24,7 @@ const Splashscreen: React.FC = () => {
 
   const startGameHandler = (): void => {
     if (localSettings) {
+      setSumType(localSettings.finalSumType);
       setBaseNum(localSettings.finalBaseNum);
       setOp1(localSettings.finalOperator);
       setTotalLives(localSettings.finalDifficulty);

--- a/src/context/SumContext.tsx
+++ b/src/context/SumContext.tsx
@@ -11,7 +11,6 @@ const SumProvider = ({ children }: Props): JSX.Element => {
   const [num2, setNum2] = useState('?' as SumState['num2']);
   const [baseNum, setBaseNum] = useState(20);
   const [op1, setOp1] = useState('+' as SumState['op1']);
-  const [op2, setOp2] = useState('=');
   const [rightWrong, setRightWrong] = useState(null as SumState['rightWrong']);
 
   const sumState = useMemo(
@@ -22,7 +21,6 @@ const SumProvider = ({ children }: Props): JSX.Element => {
       num2,
       baseNum,
       op1,
-      op2,
       rightWrong,
       setSumType,
       setPossibleNums,
@@ -30,10 +28,9 @@ const SumProvider = ({ children }: Props): JSX.Element => {
       setNum2,
       setBaseNum,
       setOp1,
-      setOp2,
       setRightWrong
     }),
-    [sumType, possibleNums, num1, num2, baseNum, op1, op2, rightWrong]
+    [sumType, possibleNums, num1, num2, baseNum, op1, rightWrong]
   );
 
   return <Provider value={sumState}>{children}</Provider>;
@@ -47,7 +44,6 @@ const useSum = (): SumState => {
     num2,
     baseNum,
     op1,
-    op2,
     rightWrong,
     setSumType,
     setPossibleNums,
@@ -55,7 +51,6 @@ const useSum = (): SumState => {
     setNum2,
     setBaseNum,
     setOp1,
-    setOp2,
     setRightWrong
   } = useContext(SumContext);
 
@@ -66,7 +61,6 @@ const useSum = (): SumState => {
     num2 === undefined ||
     baseNum === undefined ||
     op1 === undefined ||
-    op2 === undefined ||
     rightWrong === undefined ||
     setSumType === undefined ||
     setPossibleNums === undefined ||
@@ -74,7 +68,6 @@ const useSum = (): SumState => {
     setNum2 === undefined ||
     setBaseNum === undefined ||
     setOp1 === undefined ||
-    setOp2 === undefined ||
     setRightWrong === undefined
   ) {
     throw new Error('useSum must be used within a SumProvider');
@@ -87,7 +80,6 @@ const useSum = (): SumState => {
     num2,
     baseNum,
     op1,
-    op2,
     rightWrong,
     setSumType,
     setPossibleNums,
@@ -95,7 +87,6 @@ const useSum = (): SumState => {
     setNum2,
     setBaseNum,
     setOp1,
-    setOp2,
     setRightWrong
   };
 };

--- a/src/context/SumContext.tsx
+++ b/src/context/SumContext.tsx
@@ -5,6 +5,7 @@ const SumContext = React.createContext<Partial<SumState>>({});
 const { Provider } = SumContext;
 
 const SumProvider = ({ children }: Props): JSX.Element => {
+  const [sumType, setSumType] = useState('bonds' as SumState['sumType']);
   const [possibleNums, setPossibleNums] = useState([] as SumState['possibleNums']);
   const [num1, setNum1] = useState(null as SumState['num1']);
   const [num2, setNum2] = useState('?' as SumState['num2']);
@@ -15,6 +16,7 @@ const SumProvider = ({ children }: Props): JSX.Element => {
 
   const sumState = useMemo(
     () => ({
+      sumType,
       possibleNums,
       num1,
       num2,
@@ -22,6 +24,7 @@ const SumProvider = ({ children }: Props): JSX.Element => {
       op1,
       op2,
       rightWrong,
+      setSumType,
       setPossibleNums,
       setNum1,
       setNum2,
@@ -30,7 +33,7 @@ const SumProvider = ({ children }: Props): JSX.Element => {
       setOp2,
       setRightWrong
     }),
-    [possibleNums, num1, num2, baseNum, op1, op2, rightWrong]
+    [sumType, possibleNums, num1, num2, baseNum, op1, op2, rightWrong]
   );
 
   return <Provider value={sumState}>{children}</Provider>;
@@ -38,6 +41,7 @@ const SumProvider = ({ children }: Props): JSX.Element => {
 
 const useSum = (): SumState => {
   const {
+    sumType,
     possibleNums,
     num1,
     num2,
@@ -45,6 +49,7 @@ const useSum = (): SumState => {
     op1,
     op2,
     rightWrong,
+    setSumType,
     setPossibleNums,
     setNum1,
     setNum2,
@@ -55,6 +60,7 @@ const useSum = (): SumState => {
   } = useContext(SumContext);
 
   if (
+    sumType === undefined ||
     possibleNums === undefined ||
     num1 === undefined ||
     num2 === undefined ||
@@ -62,6 +68,7 @@ const useSum = (): SumState => {
     op1 === undefined ||
     op2 === undefined ||
     rightWrong === undefined ||
+    setSumType === undefined ||
     setPossibleNums === undefined ||
     setNum1 === undefined ||
     setNum2 === undefined ||
@@ -74,6 +81,7 @@ const useSum = (): SumState => {
   }
 
   return {
+    sumType,
     possibleNums,
     num1,
     num2,
@@ -81,6 +89,7 @@ const useSum = (): SumState => {
     op1,
     op2,
     rightWrong,
+    setSumType,
     setPossibleNums,
     setNum1,
     setNum2,

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -12,8 +12,8 @@ export const getNumberRange = (endNum: number): number[] => {
 
 // fn returns an array of numbers in order based on the type of sum chosen in settings
 // Runs when gameStatus is 'defineNums'
-export const definePossibleNums = (baseNum: SumState['baseNum'], op1: SumState['op1']): number[] => {
-  const numLimit = op1 === '+' ? baseNum - 1 : 12;
+export const definePossibleNums = (baseNum: SumState['baseNum'], sumType: SumState['sumType']): number[] => {
+  const numLimit = sumType === 'bonds' ? baseNum - 1 : 12;
   return getNumberRange(numLimit);
 };
 
@@ -26,13 +26,13 @@ export const answerMethod: AnswerMethodsObj = {
 
 // fn returns a single possible WRONG answer. Takes the correct answer and randomly
 // either adds or takes away a variance. Variance depends on the type of sum.
-const getWrongAnswer = (baseNum: SumState['baseNum'], op1: SumState['op1'], answer1: number): number => {
+const getWrongAnswer = (baseNum: SumState['baseNum'], sumType: SumState['sumType'], answer1: number): number => {
   const lessOrMore = getRandomNumber(2) > 0;
-  const answerVariance = op1 === '+' ? 3 : baseNum;
+  const answerVariance = sumType === 'bonds' ? 3 : baseNum;
   let wrongAnswer = lessOrMore
     ? answer1 + (getRandomNumber(answerVariance) + 1)
     : answer1 - (getRandomNumber(answerVariance) + 1);
-  if (op1 === '+') {
+  if (sumType === 'bonds') {
     wrongAnswer = wrongAnswer > baseNum ? baseNum : wrongAnswer; // Don't allow random answer to be higher than the baseNum
   }
   wrongAnswer = wrongAnswer < 0 ? 0 : wrongAnswer; // Don't allow random answer to be negative
@@ -56,6 +56,7 @@ const getNumberSet: NumberSet<number[] | WrongAnswerArgs> = (targetSetSize, func
 // answers of the correct one, and two others, also returns the correct answer by itself
 // Runs when gameStatus is 'defineSum'
 export const defineSum = (
+  sumType: SumState['sumType'],
   possibleNums: SumState['possibleNums'],
   baseNum: SumState['baseNum'],
   op1: SumState['op1']
@@ -64,7 +65,7 @@ export const defineSum = (
   const randomNum = possibleNums[getRandomNumber(possibleNums.length)];
   // fn defines correct answer, and two incorrect other possibles
   const answer1 = answerMethod[op1](baseNum, randomNum);
-  const wrongAnswerArray = [...getNumberSet(2, getWrongAnswer, [baseNum, op1, answer1])];
+  const wrongAnswerArray = [...getNumberSet(2, getWrongAnswer, [baseNum, sumType, answer1])];
   // Put the possible answers into an array, ready to be shuffled
   const answerArray = [...wrongAnswerArray, answer1];
   // Create a random order of indices of 0, 1 and 2

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -21,7 +21,9 @@ export const definePossibleNums = (baseNum: SumState['baseNum'], sumType: SumSta
 // @todo add other methods when needed
 export const answerMethod: AnswerMethodsObj = {
   '+': (a, b) => a - b,
-  x: (a, b) => a * b
+  '-': (a, b) => a - b,
+  x: (a, b) => a * b,
+  '÷': (a, b) => (a * b) / a
 };
 
 // fn returns a single possible WRONG answer. Takes the correct answer and randomly
@@ -51,6 +53,8 @@ const getNumberSet: NumberSet<number[] | WrongAnswerArgs> = (targetSetSize, func
   }
   return numberSet;
 };
+
+// fn to construct the sum depending on the operator chosen operator
 
 // fn pulls out a random number from possible number, returns an array of randomised possible
 // answers of the correct one, and two others, also returns the correct answer by itself

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,4 +1,12 @@
-import { SumState, SettingsModel, AnswerMethodsObj, DefineSumResult, NumberSet, WrongAnswerArgs } from '../types/types';
+import {
+  SumState,
+  SettingsModel,
+  AnswerMethodsObj,
+  DefineSumResult,
+  NumberSet,
+  WrongAnswerArgs,
+  SumNumberOrder
+} from '../types/types';
 
 // fn retuns a random integer with a ceiling based on the number given
 export const getRandomNumber = (base: number): number => {
@@ -54,8 +62,6 @@ const getNumberSet: NumberSet<number[] | WrongAnswerArgs> = (targetSetSize, func
   return numberSet;
 };
 
-// fn to construct the sum depending on the operator chosen operator
-
 // fn pulls out a random number from possible number, returns an array of randomised possible
 // answers of the correct one, and two others, also returns the correct answer by itself
 // Runs when gameStatus is 'defineSum'
@@ -87,4 +93,21 @@ export const getLocalSettings = (): SettingsModel | null => {
     return JSON.parse(localSettings);
   }
   return null;
+};
+
+// fn to construct the sum depending on the operator chosen operator
+export const getSumNumberOrder = (
+  operator: SumState['op1'],
+  number1: SumState['num1'],
+  number2: SumState['num2'],
+  baseNumber: SumState['baseNum']
+): SumNumberOrder => {
+  const divTotal = number1 ? number1 * baseNumber : baseNumber;
+  const numOrder = {
+    '+': [number1, number2, baseNumber],
+    '-': [baseNumber, number2, number1],
+    x: [number1, baseNumber, number2],
+    '÷': [divTotal, baseNumber, number2]
+  };
+  return numOrder[operator];
 };

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -31,7 +31,7 @@ export const answerMethod: AnswerMethodsObj = {
   '+': (a, b) => a - b,
   '-': (a, b) => a - b,
   x: (a, b) => a * b,
-  '÷': (a, b) => (a * b) / a
+  '÷': (_, b) => b
 };
 
 // fn returns a single possible WRONG answer. Takes the correct answer and randomly

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -100,3 +100,4 @@ export interface DefineSumResult {
 
 export type NumberSet<T> = (a: number, b: Function, c: T) => Set<number>;
 export type WrongAnswerArgs = [SumState['baseNum'], SumState['sumType'], number];
+export type SumNumberOrder = Array<SumState['num1'] | SumState['num2'] | SumState['baseNum']>;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -61,7 +61,6 @@ export type SumState = {
   num2: AnswerButton;
   baseNum: number;
   op1: Operator1;
-  op2: string;
   rightWrong: boolean | null;
   setSumType: StateSetter<SumState['sumType']>;
   setPossibleNums: StateSetter<SumState['possibleNums']>;
@@ -69,7 +68,6 @@ export type SumState = {
   setNum2: StateSetter<SumState['num2']>;
   setBaseNum: StateSetter<SumState['baseNum']>;
   setOp1: StateSetter<SumState['op1']>;
-  setOp2: StateSetter<SumState['op2']>;
   setRightWrong: StateSetter<SumState['rightWrong']>;
 };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -99,4 +99,4 @@ export interface DefineSumResult {
 }
 
 export type NumberSet<T> = (a: number, b: Function, c: T) => Set<number>;
-export type WrongAnswerArgs = [SumState['baseNum'], SumState['op1'], number];
+export type WrongAnswerArgs = [SumState['baseNum'], SumState['sumType'], number];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -15,7 +15,8 @@ export type GameStates =
   | 'endLose';
 
 type AnswerButton = number | '?';
-type Operator1 = '+' | 'x';
+type SumTypes = 'bonds' | 'tables';
+type Operator1 = '+' | '-' | 'x' | '÷';
 
 export type Props = { children: ReactNode };
 type StateSetter<T> = React.Dispatch<React.SetStateAction<T>>;
@@ -53,6 +54,7 @@ export type StatusState = {
 };
 
 export type SumState = {
+  sumType: SumTypes;
   possibleNums: number[];
   num1: number | null;
   num2: AnswerButton;
@@ -60,6 +62,7 @@ export type SumState = {
   op1: Operator1;
   op2: string;
   rightWrong: boolean | null;
+  setSumType: StateSetter<SumState['sumType']>;
   setPossibleNums: StateSetter<SumState['possibleNums']>;
   setNum1: StateSetter<SumState['num1']>;
   setNum2: StateSetter<SumState['num2']>;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -73,6 +73,7 @@ export type SumState = {
 };
 
 export interface SettingsModel {
+  finalSumType: SumState['sumType'];
   finalBaseNum: number;
   finalOperator: SumState['op1'];
   finalDifficulty: number;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -31,6 +31,7 @@ export type AnswerState = {
 interface WrongAnswer {
   correctAnswer: AnswerState['correctAns'];
   playerAnswer: AnswerButton;
+  completeSum: string;
 }
 
 export type ScoreState = {


### PR DESCRIPTION
### Add ability to add subtraction and divsion sums

- Add a panel to the SettingSheet component, after intial bonds or tables question to allow for choosing '+' or '-' ; or 'x' or '÷'
- Add a state of sumType: bonds to cover '+' and '-'; tables to cover 'x' and '÷'
- Add methods to provide the correct answer for '-' and '÷' sums
- Add a helper function to define the order of numbers in sums, as there are now four different orders instead of just 2; use this in the Sum and Check components
- When a sum is wrong, add the sum as a string in the Check component rather than reconstructing it in the Review component
- Some extra renaming improvements and minor refactors

(Did not refactor the SettingsSheet component as this work was big enough as is. Will do that as part of the next feature.)

#### Branch preview:
https://deploy-preview-22--seven-star-sums.netlify.app/